### PR TITLE
Nl fix garbled images

### DIFF
--- a/index.js
+++ b/index.js
@@ -314,6 +314,7 @@ Camera.prototype.setCompression = function(compression, callback) {
             this.emit('compression', compression);
           }.bind(this));
 
+          return;
         }.bind(this));
       }
     }.bind(this));
@@ -368,30 +369,6 @@ Camera.prototype.setResolution = function(resolution, callback) {
     }.bind(this));
   }.bind(this), callback);
 };
-
-Camera.prototype.takePicture2 = function (callback) {
-  this.queue.push(function (callback) { // Make the next shit the callback? // Why are u deadlocked?
-    this.setCompression (0.0, function () {
-      this._resumeFrameBuffer (function () {
-        this._stopFrameBuffer (function () {
-          this._getFrameBufferLength(function imageLengthRead(err, imgSize) {
-            // If there was a problem, report it
-            this._captureImageData(imgSize, function imageCaptured(err, image) {
-              // Wait for the camera to be ready to continue
-              if (err) {
-                if (callback) callback(err);
-                return;
-              } else {
-                this._resolveCapture(image, callback);
-              }
-            }.bind(this))
-          }.bind(this))
-        }.bind(this))
-      }.bind(this))
-    }.bind(this))
-  }.bind(this), callback, true)
-};
-
 
 // Primary method for capturing an image. Actually transfers the image over SPI Slave as opposed to UART.
 Camera.prototype.takePicture = function(callback) {


### PR DESCRIPTION
Added getCompression to firmware. This method is used primarily for debugging. By logging the uart data after calling getCompression, you'll get a packet like <Buffer 76 00 30 00 01 ff> where the final argument is the compression of the camera. 

Also, changed the compressionPacket in vclib to implement the correct protocol for setting the compression for the VC0706 camera. Right now, that feature doesn't work, but this fix will prevent people from getting garbled data after setCompression.

TODO: Implement a resolve function for getCompression which will convert the returned value into something useful.

Reviewed by: @johnnyman727 
