### PR TITLE
Initializes SPI in slave mode just before receive and does not close SPI...

### DIFF
--- a/index.js
+++ b/index.js
@@ -78,26 +78,24 @@ function Camera (hardware, options, callback) {
 util.inherits(Camera, events.EventEmitter);
 
 Camera.prototype._captureImageData = function(imgSize, callback) {
-
-   // Intialize SPI
-  var spi = this.hardware.SPI({role:'slave'});
-
   // Send the command to read the number of bytes
   this._readFrameBuffer(imgSize, function imageReadCommandSent(err) {
     // If there was a problem, report it
     if (err) {
       return callback(err);
     } else {
+      // Intialize SPI
+      var spi = this.hardware.SPI({role:'slave'});
       // Begin the transfer
       spi.receive(imgSize, function imageDataRead(err, image){
+        // Set SPI back to being a master
+        this.hardware.SPI({role:'master'});
         if (err) {
           if (callback) {
             callback(err);
           }
           return;
         } else {
-          // Close SPI
-          spi.close();
           if (callback) {
             callback(null, image);
           }


### PR DESCRIPTION
... afterward

This PR fixes Camera's functionality in conjunction with SDCard.

The main problem with using SDCard after SPI is that SDCard uses the Raw SPI API in conjunction with SPI Locks. That means that when the camera called `spi.close` after receiving the image, the sdcard was not aware that it needed to re-initialize. All of it's calls use `spi.rawTransfer` and `spi.rawReceive` which do not call the internal `spi._initialize`(to resets all of the SPI defaults for that particular SPI object).

In a similar vein, with my new changes, the SPI mode is reset to "master" once the camera is done but there is no way to preserve all the other SPI settings (for example, clockspeed gets switched from 200kHz to 100kHz after the camera transaction). Again, this is because the SPI.raw-APIs don't re-initialize SPI before taking further action.

It seems like both of those issues can be solved by calling `spi._initialize()` from within `spi.rawSend/Transfer` and `spi.rawReceive`. Are there any ramifications to that firmware change that I should consider?
